### PR TITLE
Install perl dependencies of collectd_web

### DIFF
--- a/recipes/collectd_web.rb
+++ b/recipes/collectd_web.rb
@@ -20,6 +20,10 @@
 include_recipe "collectd"
 include_recipe "apache2"
 
+%w(libhtml-parser-perl liburi-perl librrds-perl libjson-perl).each do |name|
+  package name
+end
+
 directory node[:collectd][:collectd_web][:path] do
   owner "root"
   group "root"


### PR DESCRIPTION
This commit has the collectd_web recipe install four packages. After these packages are installed, Collectd-web's check_deps.sh script reports that all its dependencies look okay. This was tested on a fresh installation of Ubuntu 12.04.
