### PR TITLE
More config options + missing rrdtool for web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ collectd_python_plugin "redis" do
 end
 ```
 
+Some plugins require you to maintain the Case Sensitivity . This cookbook follows the ruby convention to do this. Note (carbon_writer does not get install, it's just an example)
+
+```ruby
+collectd_python_plugin "carbon_writer" do
+  options  :line_receiver_host      => "127.0.0.1",
+  :line_receiver_port               => 2003,
+  :differentiate_counters_over_time => true,
+  :lowercase_metric_names           => true,
+  :types_db                         => "/usr/share/collectd/types.db"
+end
+```
+
 Options are interpreted in the same way as with `collectd_plugin`. This define will not deploy the plugin script as well, so be sure to setup a cookbook_file resource
 or other mechanism to handle distribution. Example:
 
@@ -71,7 +83,7 @@ end
 
 ## Web frontend ##
 
-The `collectd::collectd_web` recipe will automatically deploy the [collectd_web](https://github.com/httpdss/collectd-web) frontend using Apache. The 
+The `collectd::collectd_web` recipe will automatically deploy the [collectd_web](https://github.com/httpdss/collectd-web) frontend using Apache. The
 [apache2](https://github.com/opscode/cookbooks/tree/master/apache2) cookbook is required for this and is *not* included automatically as this is an optional
 component, so be sure to configure the node with the correct recipes.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The [collectd_plugins](#) cookbook is not required, but provides many common plu
 * collectd.collectd_web.path - Location to install collectd_web to. Defaults to /srv/collectd_web.
 * collectd.collectd_web.hostname - Server name to use for collectd_web Apache site.
 * collectd.collectd_web.http_port - Port the virtualhost Apache listens on
+* collectd.enable_rrdtool_plugin - Should this recipe enable a default rrdtool plugin? Defaults to true
 
 # USAGE #
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The [collectd_plugins](#) cookbook is not required, but provides many common plu
 * collectd.plugin_dir - Base folder to find plugins.
 * collectd.types_db - Array of files to read graph type information from.
 * collectd.interval - Time period in seconds to wait between data reads.
+* collectd.server_role - Name of the Chef Role to look for to identity a server. Defaults to collectd_server
+* collectd.server_ip - IP address of collectd server to use
 
 * collectd.collectd_web.path - Location to install collectd_web to. Defaults to /srv/collectd_web.
 * collectd.collectd_web.hostname - Server name to use for collectd_web Apache site.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The [collectd_plugins](#) cookbook is not required, but provides many common plu
 
 * collectd.collectd_web.path - Location to install collectd_web to. Defaults to /srv/collectd_web.
 * collectd.collectd_web.hostname - Server name to use for collectd_web Apache site.
+* collectd.collectd_web.http_port - Port the virtualhost Apache listens on
 
 # USAGE #
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The client recipe will use the search index to automatically locate the server h
 
 ## Defines ##
 
+This recipe does not install any plugins, if you want you had to include this recipe from your own recipe and add them there.
+
 Several defines are provided to simplfy configuring plugins
 
 ### collectd_plugin ###

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,4 @@ default[:collectd][:read_threads] = 5
 
 default[:collectd][:collectd_web][:path] = "/srv/collectd_web"
 default[:collectd][:collectd_web][:hostname] = "collectd"
+default[:collectd][:collectd_web][:http_port] = 80

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,10 @@ default[:collectd][:types_db] = ["/usr/share/collectd/types.db"]
 default[:collectd][:interval] = 10
 default[:collectd][:read_threads] = 5
 
+# To make the collectd web out of the box we need to 
+# activate the rrdtool plugin on the server
+default[:collectd][:enable_rrdtool_plugin] = true
+
 default[:collectd][:collectd_web][:path] = "/srv/collectd_web"
 default[:collectd][:collectd_web][:hostname] = "collectd"
 default[:collectd][:collectd_web][:http_port] = 80

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,8 @@ default[:collectd][:plugin_dir] = "/usr/lib/collectd"
 default[:collectd][:types_db] = ["/usr/share/collectd/types.db"]
 default[:collectd][:interval] = 10
 default[:collectd][:read_threads] = 5
+default[:collectd][:server_role] = "collectd_server"
+default[:collectd][:server_ip] = "127.0.0.1"
 
 # To make the collectd web out of the box we need to 
 # activate the rrdtool plugin on the server

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -20,8 +20,20 @@
 include_recipe "collectd"
 
 servers = []
-search(:node, 'recipes:"collectd::server"') do |n|
-  servers << n['fqdn']
+
+# First look for a server role
+if Chef::Config[:solo]
+  servers << node['collectd']['server_ip']
+else
+  search(:node, "role:'#{node[:collectd][:server_role]}'") do |n|
+      servers << n['fqdn']
+  end
+
+  # Then check for servers that have the collectd::server recipe
+  if servers.empty?
+    search(:node, 'recipes:"collectd::server"') do |n|
+    end
+  end
 end
 
 if servers.empty?

--- a/recipes/collectd_web.rb
+++ b/recipes/collectd_web.rb
@@ -51,3 +51,9 @@ template "/etc/apache2/sites-available/collectd_web.conf" do
 end
 
 apache_site "collectd_web.conf"
+
+if node[:collectd][:enable_rrdtool_plugin]
+  collectd_plugin "rrdtool" do
+    options :DataDir => node[:collectd][:base_dir], :CacheFlush => 120
+  end
+end

--- a/templates/default/collectd_web.conf.erb
+++ b/templates/default/collectd_web.conf.erb
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:<%= @node[:collectd][:collectd_web][:http_port] %>>
     ServerName <%= @node[:collectd][:collectd_web][:hostname] %>
 
     DocumentRoot <%= @node[:collectd][:collectd_web][:path] %>

--- a/templates/default/collection.conf.erb
+++ b/templates/default/collection.conf.erb
@@ -1,2 +1,2 @@
-datadir: "/var/lib/collectd/rrd/"
-libdir: "/usr/lib/collectd/"
+datadir: "<%= node[:collectd][:base_dir] %>"
+libdir: "<%= node[:collectd][:plugin_dir] %>"


### PR DESCRIPTION
- Added way to also search a role to find the collectd_server
- make it clear this cookbook is not for adding plugins in it but you need to do it in your own
- add rrdtool plugin to make web work out of the box (it need to be configured to point to the correct datadirectory)
- Remove hardcoding of paths in templates
- Make example for case sensitive usage in plugin definitions
- Make http_port reconfigurable
