### PR TITLE
[firewall] add firewall subrecipe

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,5 @@ description      "Install and configure the collectd monitoring daemon"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.0"
 supports         "ubuntu"
+
+suggests "iptables"

--- a/recipes/firewall.rb
+++ b/recipes/firewall.rb
@@ -1,0 +1,1 @@
+iptables_rule "port_collectd"

--- a/templates/default/port_collectd.erb
+++ b/templates/default/port_collectd.erb
@@ -1,0 +1,2 @@
+# collectd
+-A FWR -p udp --dport 25826 -j ACCEPT


### PR DESCRIPTION
- Adds a iptables firewall subrecipe as seen in https://github.com/heavywater/echelon/blob/master/cookbooks/collectd/recipes/firewall.rb
- Suggests an iptables cookbook for the firewall subrecipe

Note, the recipe will have to be explicitly added to a run list, as it isn't referenced by other recipes directly, and won't break backwards compatibility.
