### PR TITLE
Fix server search

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -20,7 +20,7 @@
 include_recipe "collectd"
 
 servers = []
-search(:node, 'recipes:"collectd::server"') do |n|
+search(:node, 'recipes:collectd\\:\\:server') do |n|
   servers << n['fqdn']
 end
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -20,7 +20,7 @@
 include_recipe "collectd"
 
 servers = []
-search(:node, 'recipes:collectd\\:\\:server') do |n|
+search(:node, "recipes:collectd\\:\\:server AND chef_environment:#{node.chef_environment}") do |n|
   servers << n['fqdn']
 end
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -20,7 +20,7 @@
 include_recipe "collectd"
 
 servers = []
-search(:node, "recipes:collectd\\:\\:server AND chef_environment:#{node.chef_environment}") do |n|
+search(:node, 'recipes:collectd\\:\\:server') do |n|
   servers << n['fqdn']
 end
 


### PR DESCRIPTION
This fixes "400 Bad Request" error with chef-client 11.6.0. It also restricts the search for nodes in the same chef environment
