### PR TITLE
Update default.rb for x86_64

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 #
 
 default[:collectd][:base_dir] = "/var/lib/collectd"
-default[:collectd][:plugin_dir] = "/usr/lib/collectd"
+default[:collectd][:plugin_dir] = kernel['machine'] =~ /x86_64/ ? '/usr/lib64/collectd' : '/usr/lib/collectd'
 default[:collectd][:types_db] = ["/usr/share/collectd/types.db"]
 default[:collectd][:interval] = 10
 default[:collectd][:read_threads] = 5


### PR DESCRIPTION
Collectd libraries are under /usr/lib64 on a 64bit machine. (Centos 6.4 at least).
