### PR TITLE
Added chef source/issues URLs to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,3 +6,6 @@ description      "Install and configure the collectd monitoring daemon"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.0.0"
 supports         "ubuntu"
+
+source_url 'hhttps://github.com/coderanger/chef-collectd' if respond_to?(:source_url)
+issues_url 'https://github.com/coderanger/chef-collectd/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Used by supermarket to detect a cookbook's source and issues links. Issues link is currently missing from supermarket. 

Signed-off-by: Robert Northard robertnorthard@googlemail.com
